### PR TITLE
This change allows to seamlessly handle *.properties configs packed inside JAR files. All *.properties listing and loading operations are now based on Resources instead of Files. Spring's PathMatchingResourcePatternResolver has been extended and used for listing available *.properties.

### DIFF
--- a/cm-config-for-unit-test/pom.xml
+++ b/cm-config-for-unit-test/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>cm-config-for-unit-test</artifactId>
+    <parent>
+        <groupId>ch.racic.testing</groupId>
+        <artifactId>test-configuration-manager-parent</artifactId>
+        <version>0.13.0-SNAPSHOT</version>
+        <relativePath>..</relativePath>
+    </parent>
+    <name>Test Configuration Config for Unit Test</name>
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.3</version>
+                <configuration>
+                    <source>1.6</source>
+                    <target>1.6</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/cm-config-for-unit-test/src/main/resources/customConfigFolder/env1/class/testCmConfigInsideJar.properties
+++ b/cm-config-for-unit-test/src/main/resources/customConfigFolder/env1/class/testCmConfigInsideJar.properties
@@ -1,0 +1,1 @@
+config.insideJar.myvalue.env1.class.only = env1.class

--- a/cm-config-for-unit-test/src/main/resources/customConfigFolder/env1/insideJarTest.properties
+++ b/cm-config-for-unit-test/src/main/resources/customConfigFolder/env1/insideJarTest.properties
@@ -1,0 +1,1 @@
+config.test.loadedfrom = env1/insideJarTest.properties

--- a/cm-config-for-unit-test/src/main/resources/customConfigFolder/env1/insideJarTest_de.properties
+++ b/cm-config-for-unit-test/src/main/resources/customConfigFolder/env1/insideJarTest_de.properties
@@ -1,0 +1,1 @@
+config.test.loadedfrom = env1/insideJarTest_de.properties

--- a/cm-config-for-unit-test/src/main/resources/customConfigFolder/global/class/testCmConfigInsideJar.properties
+++ b/cm-config-for-unit-test/src/main/resources/customConfigFolder/global/class/testCmConfigInsideJar.properties
@@ -1,0 +1,1 @@
+config.insideJar.myvalue.global.class.only = global.class

--- a/cm-config-for-unit-test/src/main/resources/customConfigFolder/global/insideJarTest.properties
+++ b/cm-config-for-unit-test/src/main/resources/customConfigFolder/global/insideJarTest.properties
@@ -1,0 +1,1 @@
+config.test.loadedfrom = global/insideJarTest.properties

--- a/cm-core/pom.xml
+++ b/cm-core/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>test-configuration-manager</artifactId>
@@ -37,10 +38,30 @@
         </dependency>
 
         <dependency>
+            <groupId>ch.racic.testing</groupId>
+            <artifactId>cm-config-for-unit-test</artifactId>
+            <version>0.13.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
             <version>2.2</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>4.2.1.RELEASE</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.4</version>
+        </dependency>
+
 
     </dependencies>
 

--- a/cm-core/src/main/java/ch/racic/testing/cm/AggregatedResourceBundle.java
+++ b/cm-core/src/main/java/ch/racic/testing/cm/AggregatedResourceBundle.java
@@ -36,6 +36,12 @@ public class AggregatedResourceBundle extends ResourceBundle {
     public AggregatedResourceBundle() {
     }
 
+    public AggregatedResourceBundle(AggregatedResourceBundle toCopy) {
+        if (toCopy!= null && toCopy.contents!=null) {
+            this.contents.putAll(toCopy.contents);
+        }
+    }
+
     /**
      * Merge the new bundle into the existing while overriding already existing keys.
      *
@@ -54,6 +60,16 @@ public class AggregatedResourceBundle extends ResourceBundle {
     @Override
     public Enumeration<String> getKeys() {
         return new IteratorEnumeration<String>(contents.keySet().iterator());
+    }
+
+    @Override
+    public boolean containsKey(String key){
+        return contents.containsKey(key);
+    }
+
+    @Override
+    public Set<String> keySet(){
+        return contents.keySet();
     }
 
     @Override

--- a/cm-core/src/main/java/ch/racic/testing/cm/PropertyFileResolver.java
+++ b/cm-core/src/main/java/ch/racic/testing/cm/PropertyFileResolver.java
@@ -1,0 +1,89 @@
+package ch.racic.testing.cm;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver;
+
+import java.util.*;
+
+public class PropertyFileResolver extends PathMatchingResourcePatternResolver {
+
+    private static final Logger log = LogManager.getLogger(PathMatchingResourcePatternResolver.class);
+
+    private final Resource configRootRes;
+
+    private final Set<String> allLocales;
+
+    public PropertyFileResolver(String configRoot) {
+        super();
+        try {
+            String rootDirPattern = "classpath*:" + configRoot;
+
+            Resource[] res = getResources(rootDirPattern);
+            if (res.length == 0) {
+                throw new RuntimeException("There is no resource matching root pattern: " + rootDirPattern);
+            }
+
+            for (Resource r : res) {
+                log.debug("Discovered root configuration resource: " + r.toString());
+            }
+
+            configRootRes = res[0];
+            log.debug("Root configuration resource set to: " + configRootRes.toString());
+
+            //stores all JVM Locales only once, used to return only base property names
+            allLocales = new HashSet<String>();
+            for (Locale loc : Locale.getAvailableLocales()) {
+                allLocales.add(loc.toString());
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public boolean resourceExists(String subDirectory) {
+        if (subDirectory == null) {
+            return false;
+        }
+        try {
+            subDirectory = StringUtils.removeEnd(subDirectory, "/");
+            if (isJarResource(configRootRes)) {
+                subDirectory += "/";
+                return !doFindPathMatchingJarResources(configRootRes, subDirectory).isEmpty();
+            } else {
+                return !doFindPathMatchingFileResources(configRootRes, subDirectory).isEmpty();
+            }
+        } catch (Exception e) {
+            throw new RuntimeException();
+        }
+    }
+
+    public List<String> findAllBasePropertyFilenames(String subDirectory) {
+        try {
+            String subPattern = StringUtils.removeEnd(subDirectory, "/");
+            subPattern += "/*.properties";
+            TreeSet<String> properties = new TreeSet<String>();
+            Set<Resource> res = null;
+            if (isJarResource(configRootRes)) {
+                res = doFindPathMatchingJarResources(configRootRes, subPattern);
+            } else {
+                res = doFindPathMatchingFileResources(configRootRes, subPattern);
+            }
+
+            for (Resource r : res) {
+                String baseName = StringUtils.removeEnd(r.getFilename(), ".properties");
+
+                String loc = StringUtils.substringAfterLast(baseName, "_");
+                //omit properties which are locale specific, return base names
+                if (StringUtils.isBlank(loc) || !allLocales.contains(loc)) {
+                    properties.add(baseName);
+                }
+            }
+            return new ArrayList<String>(properties);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/cm-core/src/test/java/ch/racic/testing/cm/AggregatedResourceBundleTest.java
+++ b/cm-core/src/test/java/ch/racic/testing/cm/AggregatedResourceBundleTest.java
@@ -1,0 +1,27 @@
+package ch.racic.testing.cm;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+import java.util.ResourceBundle;
+
+public class AggregatedResourceBundleTest {
+
+    @Test
+    public void testMergeOverride() throws Exception {
+        AggregatedResourceBundle resourceBundle = new AggregatedResourceBundle();
+        assertEquals(0, resourceBundle.keySet().size());
+
+        ResourceBundle testResBundle = ResourceBundle.getBundle(ConfigProvider.CONFIG_BASE_FOLDER + "." + ConfigProvider.CONFIG_GLOBAL_BASE_FOLDER + ".test");
+        ResourceBundle test2ResBundle = ResourceBundle.getBundle(ConfigProvider.CONFIG_BASE_FOLDER + "." + ConfigProvider.CONFIG_GLOBAL_BASE_FOLDER + ".test2");
+        assertEquals(6, testResBundle.keySet().size());
+        assertEquals(5, test2ResBundle.keySet().size());
+
+        resourceBundle.mergeOverride(testResBundle);
+        assertEquals(6, resourceBundle.keySet().size());
+
+        resourceBundle.mergeOverride(test2ResBundle);
+        assertEquals(11, resourceBundle.keySet().size());
+    }
+}

--- a/cm-core/src/test/java/ch/racic/testing/cm/InsideJarPropertiesTest.java
+++ b/cm-core/src/test/java/ch/racic/testing/cm/InsideJarPropertiesTest.java
@@ -1,0 +1,37 @@
+package ch.racic.testing.cm;
+
+
+import ch.racic.testing.cm.annotation.ClassConfig;
+import org.testng.Assert;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+import java.util.Locale;
+import java.util.Properties;
+
+@ClassConfig(fileName = "testCmConfigInsideJar")
+public class InsideJarPropertiesTest {
+
+    @Test
+    @Parameters({"environment.code", "environment.locale" })
+    public void checkRuntimeProperties(@Optional String environmentCodeIn, @Optional String environmentLocale) throws Exception {
+        Properties props = new Properties();
+        props.put(ConfigProvider.CONFIG_BASE_FOLDER_SYSTEM_KEY, "customConfigFolder");
+
+        Locale locale = environmentLocale != null ? Locale.forLanguageTag(environmentLocale) : null;
+        ConfigEnvironment env = environmentCodeIn != null ? new ConfigEnvironment(null, null, environmentCodeIn, locale) : null;
+        ConfigProvider cfg = new ConfigProvider(null, env, this.getClass(), null, props);
+        Assert.assertEquals(cfg.get("config.insideJar.myvalue.global.class.only"), "global.class", "Property has been read successfully from global class config properties inside a jar file");
+
+        String environmentCode = environmentCodeIn;
+        if (environmentCode == null || environmentCode.contentEquals("envBlaBla")) environmentCode = "global";
+        String environmentLocaleAppendix = "";
+        if (environmentLocale != null) environmentLocaleAppendix = "_" + environmentLocale;
+
+        if ("env1".equals(environmentCode)) {
+            Assert.assertEquals(cfg.get("config.insideJar.myvalue.env1.class.only"), "env1.class", "Property has been read successfully from env class config properties inside a jar file");
+        }
+        Assert.assertEquals(cfg.get("config.test.loadedfrom"), environmentCode + "/insideJarTest" + environmentLocaleAppendix + ".properties", "config.test.loaded.from gets overwritten by env folder or taken from global if no environment is specified");
+    }
+}

--- a/cm-core/src/test/resources/config/env1/class/OnDemandTest.properties
+++ b/cm-core/src/test/resources/config/env1/class/OnDemandTest.properties
@@ -1,0 +1,1 @@
+runtime.loaded=env1/class/OnDemandTest.properties

--- a/cm-core/src/test/resources/config/global/class/OnDemandTest.properties
+++ b/cm-core/src/test/resources/config/global/class/OnDemandTest.properties
@@ -1,0 +1,1 @@
+runtime.loaded=global/class/OnDemandTest.properties

--- a/cm-core/src/test/testng/allMethodsParallel.xml
+++ b/cm-core/src/test/testng/allMethodsParallel.xml
@@ -11,6 +11,8 @@
             <class name="ch.racic.testing.cm.InjectTest"/>
             <class name="ch.racic.testing.cm.CustomPropertiesTest"/>
             <class name="ch.racic.testing.cm.NoPropertiesTest"/>
+            <class name="ch.racic.testing.cm.InsideJarPropertiesTest"/>
+            <class name="ch.racic.testing.cm.AggregatedResourceBundleTest"/>
         </classes>
     </test>
     <test name="With environment and locale">
@@ -21,6 +23,8 @@
             <class name="ch.racic.testing.cm.InjectTest"/>
             <class name="ch.racic.testing.cm.CustomPropertiesTest"/>
             <class name="ch.racic.testing.cm.NoPropertiesTest"/>
+            <class name="ch.racic.testing.cm.InsideJarPropertiesTest"/>
+            <class name="ch.racic.testing.cm.AggregatedResourceBundleTest"/>
         </classes>
     </test>
     <test name="With not existing environment">
@@ -30,6 +34,8 @@
             <class name="ch.racic.testing.cm.InjectTest"/>
             <class name="ch.racic.testing.cm.CustomPropertiesTest"/>
             <class name="ch.racic.testing.cm.NoPropertiesTest"/>
+            <class name="ch.racic.testing.cm.InsideJarPropertiesTest"/>
+            <class name="ch.racic.testing.cm.AggregatedResourceBundleTest"/>
         </classes>
     </test>
 </suite>

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>cm-config-for-unit-test</module>
         <module>cm-core</module>
         <module>maven-cm-plugin</module>
     </modules>


### PR DESCRIPTION
This change allows to seamlessly handle *.properties configs packed inside JAR files. All *.properties listing and loading operations are now based on Resources instead of Files. Spring's PathMatchingResourcePatternResolver has been extended and used for listing available *.properties.